### PR TITLE
Improved performance of fft imports/updates (10s -> 0.5s)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# pycharm
+.idea

--- a/dal/licco.py
+++ b/dal/licco.py
@@ -9,6 +9,8 @@ from enum import Enum
 import copy
 import json
 import math
+from typing import Tuple, Dict
+
 import pytz
 import tempfile
 
@@ -123,7 +125,7 @@ def get_fft_name_by_id(fftid):
     fc = licco_db[line_config_db_name]["fcs"].find_one(
         {"_id": fft["fc"]})
     fg = licco_db[line_config_db_name]["fgs"].find_one(
-        {"_id": fft["fg"]}) 
+        {"_id": fft["fg"]})
     return fc["name"], fg["name"]
 
 def get_fft_id_by_names(fc, fg):
@@ -136,7 +138,7 @@ def get_fft_id_by_names(fc, fg):
     fc_obj = licco_db[line_config_db_name]["fcs"].find_one(
         {"name": fc})
     fg_obj = licco_db[line_config_db_name]["fgs"].find_one(
-        {"name": fg}) 
+        {"name": fg})
     fft = licco_db[line_config_db_name]["ffts"].find_one(
         {"fc": ObjectId(fc_obj["_id"]), "fg": ObjectId(fg_obj["_id"])})
     return fft["_id"]
@@ -569,21 +571,30 @@ def get_fcattrs(fromstr=False):
     return fcattrscopy
 
 
-def update_fft_in_project(prjid, fftid, fcupdate, userid, modification_time=None):
+def update_fft_in_project(prjid, fftid, fcupdate, userid,
+                          modification_time=None,
+                          current_project_attributes=None) -> Tuple[bool, str, Dict[str, int]]:
     """
     Update the value(s) of an FFT in a project
+    Returns: a tuple containing (success flag (true/false if error), error message (if any), and an insert count
     """
+    insert_count = {"success": 0, "fail": 0, "ignored": 0}
     prj = licco_db[line_config_db_name]["projects"].find_one(
         {"_id": ObjectId(prjid)})
     if not prj:
-        return False, f"Cannot find project for {prjid}", None, None
+        return False, f"Cannot find project for {prjid}", insert_count
     fft = licco_db[line_config_db_name]["ffts"].find_one(
         {"_id": ObjectId(fftid)})
     if not fft:
-        return False, f"Cannot find functional+fungible token for {fftid}", None, None
+        return False, f"Cannot find functional+fungible token for {fftid}", insert_count
 
-    current_attrs = get_project_attributes(
-        licco_db[line_config_db_name], ObjectId(prjid)).get(str(fftid), {})
+    current_attrs = current_project_attributes
+    if current_attrs is None:
+        # NOTE: current_project_attributes should be provided when lots of ffts are updated at the same time, e.g.:
+        # for 100 ffts, we shouldn't query the entire project attributes 100 times as that is very slow
+        # (cca 150-300 ms per query).
+        current_attrs = get_project_attributes(
+            licco_db[line_config_db_name], ObjectId(prjid)).get(str(fftid), {})
 
     if not modification_time:
         modification_time = datetime.datetime.utcnow().replace(tzinfo=pytz.utc)
@@ -592,23 +603,22 @@ def update_fft_in_project(prjid, fftid, fcupdate, userid, modification_time=None
         {}).sort([("time", -1)]).limit(1))
     if latest_changes:
         if modification_time < latest_changes[0]["time"]:
-            return False, f"The time on this server {modification_time.isoformat()} is before the most recent change from the server {latest_changes[0]['time'].isoformat()}", None, None
+            return False, f"The time on this server {modification_time.isoformat()} is before the most recent change from the server {latest_changes[0]['time'].isoformat()}", insert_count
 
     if "state" in fcupdate and fcupdate["state"] != "Conceptual":
         for attrname, attrmeta in fcattrs.items():
             if (attrmeta.get("is_required_dimension") is True) and ((current_attrs.get(attrname, None) is None) and (fcupdate[attrname] is None)):
-                return False, "FFTs should remain in the Conceptual state while the dimensions are still being determined.", None, None
+                return False, "FFTs should remain in the Conceptual state while the dimensions are still being determined.", insert_count
 
     error_str = ""
     all_inserts = []
     fft_edits = set()
-    insert_count = {"success": 0, "fail": 0, "ignored": 0}
     for attrname, attrval in fcupdate.items():
         if attrname == "fft":
             continue
         attrmeta = fcattrs[attrname]
         if attrmeta["required"] and not attrval:
-            return False, f"Parameter {attrname} is a required attribute", None, insert_count
+            return False, f"Parameter {attrname} is a required attribute", insert_count
         try:
             newval = attrmeta["fromstr"](attrval)
         except ValueError:
@@ -635,19 +645,21 @@ def update_fft_in_project(prjid, fftid, fcupdate, userid, modification_time=None
 
     #If one of the fields is invalid, and we have an error
     if error_str != "":
-        return False, error_str, get_project_attributes(licco_db[line_config_db_name], ObjectId(prjid)), insert_count
+        return False, error_str, insert_count
     if all_inserts:
-        logger.debug("Inserting %s documents into the history",
-                     len(all_inserts))
-        insert_count["success"] +=1
-        licco_db[line_config_db_name]["projects_history"].insert_many(
-            all_inserts)
+        logger.debug("Inserting %s documents into the history", len(all_inserts))
+        insert_count["success"] += 1
+        licco_db[line_config_db_name]["projects_history"].insert_many(all_inserts)
     else:
-        insert_count["ignored"] +=1
+        insert_count["ignored"] += 1
         logger.debug("In update_fft_in_project, all_inserts is an empty list")
         error_str = "No changes detected."
-        return None, error_str, get_project_attributes(licco_db[line_config_db_name], ObjectId(prjid)), insert_count
-    return True, error_str, get_project_attributes(licco_db[line_config_db_name], ObjectId(prjid)), insert_count
+        return True, error_str, insert_count
+    return True, error_str, insert_count
+
+
+def query_project_attributes(proj_id):
+    return get_project_attributes(licco_db[line_config_db_name], ObjectId(proj_id))
 
 
 def validate_insert_range(attr, val):
@@ -837,7 +849,7 @@ def get_projects_recent_edit_time():
     projects = licco_db[line_config_db_name]["projects"].find()
     for project in projects:
         most_recent = licco_db[line_config_db_name]["projects_history"].find_one(
-        {"prj":ObjectId(project["_id"])}, {"time": 1 }, sort=[("time", DESCENDING )]) 
+        {"prj":ObjectId(project["_id"])}, {"time": 1 }, sort=[("time", DESCENDING )])
         if not most_recent:
             most_recent = {"_id": "", "time": ""}
         edit_list[project["_id"]] = most_recent
@@ -935,10 +947,10 @@ def clone_project(prjid, name, description, userid, new=False):
     newprj = create_new_project(name, description, userid)
     if not newprj:
         return False, "Created a project but could not get the object from the database", None
-    
+
     if new == True:
         return True, "", newprj
- 
+
     myfcs = get_project_attributes(licco_db[line_config_db_name], prjid)
 
     modification_time = newprj["creation_time"]

--- a/dal/licco.py
+++ b/dal/licco.py
@@ -658,10 +658,6 @@ def update_fft_in_project(prjid, fftid, fcupdate, userid,
     return True, error_str, insert_count
 
 
-def query_project_attributes(proj_id):
-    return get_project_attributes(licco_db[line_config_db_name], ObjectId(proj_id))
-
-
 def validate_insert_range(attr, val):
     """
     Helper function to validate data prior to being saved in DB

--- a/services/licco.py
+++ b/services/licco.py
@@ -10,11 +10,8 @@ import re
 from io import BytesIO, StringIO
 from datetime import datetime
 import pytz
-import copy
 import tempfile
 from functools import wraps
-from pprint import pprint
-
 import context
 
 from flask import Blueprint, request, Response, send_file, render_template
@@ -24,10 +21,12 @@ from dal.licco import get_fcattrs, get_project, get_project_ffts, get_fcs, \
     create_new_functional_component, update_fft_in_project, submit_project_for_approval, approve_project, \
     get_currently_approved_project, diff_project, FCState, clone_project, get_project_changes, \
     get_tags_for_project, add_project_tag, get_all_projects, get_all_users, update_project_details, get_project_by_name, \
-    create_empty_project, reject_project, copy_ffts_from_project, get_fgs, create_new_fungible_token, get_ffts, create_new_fft, \
-    get_projects_approval_history, delete_fft, delete_fc, delete_fg, get_project_attributes, validate_insert_range, get_fft_values_by_project, \
-    get_users_with_privilege, get_fft_name_by_id, get_fft_id_by_names, get_projects_recent_edit_time
-
+    create_empty_project, reject_project, copy_ffts_from_project, get_fgs, create_new_fungible_token, get_ffts, \
+    create_new_fft, \
+    get_projects_approval_history, delete_fft, delete_fc, delete_fg, get_project_attributes, validate_insert_range, \
+    get_fft_values_by_project, \
+    get_users_with_privilege, get_fft_name_by_id, get_fft_id_by_names, get_projects_recent_edit_time, \
+    line_config_db_name, query_project_attributes
 
 __author__ = 'mshankar@slac.stanford.edu'
 
@@ -98,6 +97,7 @@ def create_imp_msg(fft, status, errormsg=None):
     msg = f"{res}: {fft['fc']}-{fft['fg']} - {errormsg}"
     return msg
 
+
 def update_ffts_in_project(prjid, ffts, def_logger=None):
     """
     Insert multiple FFTs into a project
@@ -111,9 +111,16 @@ def update_ffts_in_project(prjid, ffts, def_logger=None):
         for entry in ffts:
             new_ffts.append(ffts[entry])
         ffts = new_ffts
+
+    current_attrs = query_project_attributes(prjid)
+
     # Iterate through parameter fft set
     for fft in ffts:
         if "_id" not in fft:
+            # REVIEW: the database layer should return the kind of structure that you
+            # need, so you don't have to fix it everyhwere that structure is used.
+            # That fix should be already in the database layer.
+            #
             # If the fft set comes from the database, unpack the fft ids
             if "fft" in fft:
                 fft["_id"] = fft["fft"]["_id"]
@@ -128,7 +135,7 @@ def update_ffts_in_project(prjid, ffts, def_logger=None):
         # previous values
         db_values = get_fft_values_by_project(fft["_id"], prjid)
         fcupdate = {}
-        fcupdate.update(fft)   
+        fcupdate.update(fft)
         if ("state" not in fcupdate) or (not fcupdate["state"]):
             if "state" in db_values:
                 fcupdate["state"] = db_values["state"]
@@ -143,15 +150,23 @@ def update_ffts_in_project(prjid, ffts, def_logger=None):
         for attr in ["_id", "name", "fc", "fg", "fft"]:
             if attr in fcupdate:
                 del fcupdate[attr]
-        status, errormsg, prj_fft, results = update_fft_in_project(
-            prjid, fftid, fcupdate, userid)
+
+        # Performance: when updating fft in a project, we used to do hundreds of database calls
+        # which was very slow. An import of a few ffts took 10 seconds. We speed this up, by
+        # querying the current project attributes once and passing it to the update routine
+        current_project_attributes = current_attrs.get(str(fftid), {})
+        status, errormsg, results = update_fft_in_project(prjid, fftid, fcupdate, userid,
+                                                          current_project_attributes=current_project_attributes)
         # Have smarter error handling here for different exit conditions
         def_logger.info(create_imp_msg(fft, status=status, errormsg=errormsg))
- 
+
         # Add the individual FFT update results into overall count
         if results:
             update_status = {k: update_status[k]+results[k]
                              for k in update_status.keys()}
+
+    # BUG: error message is not declared anywhere, so it will always be None or set to the last value
+    # that comes out of fft update loop
     return True, errormsg, get_project_ffts(prjid, showallentries=True, asoftimestamp=None), update_status
 
 
@@ -504,11 +519,8 @@ def svc_update_fc_in_project(prjid, fftid):
     status, msg = validate_import_headers(fcupdate, prjid, fftid)
     if not status:
         return JSONEncoder().encode({"success": False, "errormsg": msg})
-    status, errormsg, fc, results = update_fft_in_project(
-        prjid, fftid, fcupdate, userid)
-    # No changes were detected
-    if status is None:
-        status = True
+    status, errormsg, results = update_fft_in_project(prjid, fftid, fcupdate, userid)
+    fc = query_project_attributes(prjid)
     return JSONEncoder().encode({"success": status, "errormsg": errormsg, "value": fc})
 
 
@@ -682,7 +694,7 @@ def svc_import_project(prjid):
     if update_status:
         status_val = {k: update_status[k]+status_val[k]
                             for k in update_status.keys()}
-        
+
     # number of recognized headers minus the id used for DB reference
     status_val["headers"] = len(fcuploads[0].keys())-1
     status_str = create_status_update(prj_name, status_val)
@@ -707,7 +719,7 @@ def svc_download_report(report):
         repfile = f"{dir_path}/{report}.log"
         return send_file(f"{repfile}",as_attachment=True,mimetype="text/plain")
     except FileNotFoundError:
-        return JSONEncoder().encode({"success": False, "errormsg": "Something went wrong.", "value": None}) 
+        return JSONEncoder().encode({"success": False, "errormsg": "Something went wrong.", "value": None})
 
 @licco_ws_blueprint.route("/projects/<prjid>/export/", methods=["GET"])
 @context.security.authentication_required

--- a/static/html/tabs/prjimport.html
+++ b/static/html/tabs/prjimport.html
@@ -13,7 +13,7 @@
                   <div class="text-danger errormsg"></div>
                   <div class="mb-3">
                     <div class="text">This will upload a csv to update the selected project.<br>
-                      During MCD Open Beta, only file sizes under 15KB(~150 rows) are allowed.</div>
+                      During MCD Open Beta, only file sizes under 15MB are allowed.</div>
                     <br>
                     <p class="text-danger" id="error_msg"></p>
                   </div>

--- a/static/html/tabs/project.html
+++ b/static/html/tabs/project.html
@@ -365,7 +365,7 @@
       document.getElementById('projectname').innerHTML=project_name;
       $("#global_mdl_holder").find(".modal").modal("show");
       $("#global_mdl_holder").find(".fileuploader")[0].addEventListener("change", event => {
-        if(event.target.files[0].size > 15000) {
+        if (event.target.files[0].size > 15000000) {
               document.getElementById("import_sub_btn").disabled = true;
               document.getElementById('error_msg').style.display = 'block';
               var err_msg = "The file is too large at " + event.target.files[0].size;

--- a/static/html/tabs/projects.html
+++ b/static/html/tabs/projects.html
@@ -128,7 +128,7 @@ $("#projects_tab").on("lg.loaded.bs.tab", function() {
           document.getElementById('projectname').innerHTML=prjnm;
           $("#global_mdl_holder").find(".modal").modal("show");
           $("#global_mdl_holder").find(".fileuploader")[0].addEventListener("change", event => {
-            if(event.target.files[0].size > 15000) {
+            if (event.target.files[0].size > 15000000) {
               document.getElementById("import_sub_btn").disabled = true;
               document.getElementById('error_msg').style.display = 'block';
               var err_msg = "The file is too large at " + event.target.files[0].size;


### PR DESCRIPTION
This is just a small change that caches the attributes instead of querying them on every update. The mongo query itself is quite inefficient (it joins the fc, fg for every document when we only need that at the end of aggregation (1000 fetches vs 80) but since it only takes 0.1-0.3s we may stop here for now.

@laura-king