### PR TITLE
Project approval history

### DIFF
--- a/dal/licco.py
+++ b/dal/licco.py
@@ -912,12 +912,13 @@ def store_project_approval(prjid: str, project_submitter: str):
         "switch_time": datetime.datetime.utcnow()
     })
 
-def get_projects_approval_history():
+def get_projects_approval_history(limit: int = 100):
     """
     Get the history of project approvals
     """
     hist = list(licco_db[line_config_db_name]["switch"].aggregate([
         {"$sort": {"switch_time": -1}},
+        {"$limit": limit},
         {"$lookup": {"from": "projects", "localField": "prj",
                      "foreignField": "_id", "as": "prjobj"}},
         {"$unwind": "$prjobj"},

--- a/dal/licco.py
+++ b/dal/licco.py
@@ -856,6 +856,8 @@ def approve_project(prjid, userid) -> Tuple[bool, bool, str, Dict[str, any]]:
                                                             "status": "approved", "approved_time": datetime.datetime.utcnow()}})
 
     licco_db[line_config_db_name]["projects"].update_one({"_id": prj["_id"]}, {"$set": updated_project_data})
+    store_project_approval(prjid, prj["submitter"])
+
     updated_project = licco_db[line_config_db_name]["projects"].find_one({"_id": prj["_id"]})
     return True, all_assigned_approvers_approved, f"Project {updated_project['name']} approved by {updated_project['submitter']}.", updated_project
 
@@ -902,6 +904,13 @@ def get_currently_approved_project():
     if prj and prj["status"] == "approved":
         return prj
     return None
+
+def store_project_approval(prjid: str, project_submitter: str):
+    licco_db[line_config_db_name]["switch"].insert_one({
+        "prj": ObjectId(prjid),
+        "requestor_uid": project_submitter,
+        "switch_time": datetime.datetime.utcnow()
+    })
 
 def get_projects_approval_history():
     """

--- a/services/licco.py
+++ b/services/licco.py
@@ -933,4 +933,4 @@ def svc_get_projects_approval_history():
     """
     Get the approval history of projects in the system
     """
-    return JSONEncoder().encode({"success": True, "value": get_projects_approval_history()})
+    return JSONEncoder().encode({"success": True, "value": get_projects_approval_history(limit=100)})


### PR DESCRIPTION
Approval history endpoint is now returning data.

Q: Should we limit the maximum number of  returned approvals to some reasonable number (e..g, last 100 approvals)? Otherwise with enough time we may end up with returning too much data for the frontend to handle (most of which the user is not even interested in).