### PR TITLE
Remove device from a project

### DIFF
--- a/dal/licco.py
+++ b/dal/licco.py
@@ -847,13 +847,13 @@ def remove_ffts_from_project(userid, prjid, fft_ids: List[str]):
 
     # this will delete every stored value (history of value changes and discussion comment for this device)
     ids = [ObjectId(x) for x in fft_ids]
-    result = licco_db[line_config_db_name]["projects_history"].delete_many({"fft": {"$in": ids}})
+    result = licco_db[line_config_db_name]["projects_history"].delete_many({'$and': [{"fft": {"$in": ids}}, {"prj": ObjectId(prjid)}]})
     if result.deleted_count == 0:
         # this should never happen when using the GUI (the user can only delete a device if a device is displayed
         # in a GUI (with a valid id) - there should always be at least one such document.
         # Nevertheless, this situation can happen if someone decides to delete a device via a REST API
         # while providing a list of invalid ids.
-        return True, f"Chosen ffts {fft_ids} do not exist"
+        return False, f"Chosen ffts {fft_ids} do not exist"
     return True, ""
 
 def submit_project_for_approval(prjid: str, userid: str, approvers: List[str]):

--- a/dal/licco.py
+++ b/dal/licco.py
@@ -847,7 +847,7 @@ def remove_ffts_from_project(userid, prjid, fft_ids: List[str]):
 
     # this will delete every stored value (history of value changes and discussion comment for this device)
     ids = [ObjectId(x) for x in fft_ids]
-    result = licco_db[line_config_db_name]["projects_history"].delete_many({'$and': [{"fft": {"$in": ids}}, {"prj": ObjectId(prjid)}]})
+    result = licco_db[line_config_db_name]["projects_history"].delete_many({'$and': [{"prj": ObjectId(prjid)}, {"fft": {"$in": ids}}]})
     if result.deleted_count == 0:
         # this should never happen when using the GUI (the user can only delete a device if a device is displayed
         # in a GUI (with a valid id) - there should always be at least one such document.

--- a/react/src/app/projects/[projectId]/project_details.tsx
+++ b/react/src/app/projects/[projectId]/project_details.tsx
@@ -547,7 +547,6 @@ export const ProjectDetails: React.FC<{ projectId: string }> = ({ projectId }) =
                     }}
                     onConfirm={(e) => {
                         const fft = currentFFT
-                        console.log(fft);
                         removeFftsFromProject(project._id, [fft])
                             .then(() => {
                                 setCurrentFFT({ _id: '', fc: '', fg: '' });

--- a/react/src/app/projects/project_model.tsx
+++ b/react/src/app/projects/project_model.tsx
@@ -409,6 +409,12 @@ export function addFftsToProject(projectId: string, ffts: ProjectFFT[]): Promise
         })
 }
 
+export function removeFftsFromProject(projectId: string, fft: ProjectFFT[]): Promise<void> {
+    let ids = fft.map(fft => fft._id);
+    let data = { 'ids': ids };
+    return Fetch.delete<void>(`/ws/projects/${projectId}/ffts/`, { body: JSON.stringify(data) })
+}
+
 export async function approveProject(projectId: string): Promise<ProjectInfo> {
     return Fetch.post<ProjectInfo>(`/ws/projects/${projectId}/approve_project`)
         .then((project) => {

--- a/services/licco.py
+++ b/services/licco.py
@@ -28,7 +28,7 @@ from dal.licco import get_fcattrs, get_project, get_project_ffts, get_fcs, \
     get_projects_approval_history, delete_fft, delete_fc, delete_fg, get_project_attributes, validate_insert_range, \
     get_fft_values_by_project, \
     get_users_with_privilege, get_fft_name_by_id, get_fft_id_by_names, get_projects_recent_edit_time, \
-    delete_fft_comment, add_fft_comment
+    delete_fft_comment, add_fft_comment, remove_ffts_from_project
 
 __author__ = 'mshankar@slac.stanford.edu'
 
@@ -640,6 +640,18 @@ def svc_update_ffts_in_project(prjid):
     status, errormsg, update_status = update_ffts_in_project(prjid, ffts)
     fft = get_project_ffts(prjid)
     return JSONEncoder().encode({"success": status, "errormsg": errormsg, "value": fft})
+
+@licco_ws_blueprint.route("/projects/<prjid>/ffts/", methods=["DELETE"])
+@project_writable
+@context.security.authentication_required
+def svc_remove_ffts_from_project(prjid):
+    """
+    Remove multiple ffts/devices from a project
+    """
+    userid = context.security.get_current_user_id()
+    fft_ids = request.json.get('ids', [])
+    status, errormsg = remove_ffts_from_project(userid, prjid, fft_ids)
+    return JSONEncoder().encode({"success": status, "errormsg": errormsg})
 
 
 @licco_ws_blueprint.route("/projects/<prjid>/import/", methods=["POST"])


### PR DESCRIPTION
A project editor can now remove a device from a project.

This will delete every value change from the "projects_history" db table for the given device. This is how the db currently works, and I think its good enough for the MVP. Later on we can discuss other options (such as ignoring certain values via 'deleted' flag instead of deleting them from the db)