### PR TITLE
Error Handling for FFT Update with wrong columns

### DIFF
--- a/dal/licco.py
+++ b/dal/licco.py
@@ -693,8 +693,12 @@ def update_fft_in_project(prjid, fftid, fcupdate, userid,
                     "time": modification_time
                 })
             continue
-
-        attrmeta = fcattrs[attrname]
+        try:
+            attrmeta = fcattrs[attrname]
+        except KeyError:
+            logger.debug(f"Parameter {attrname} is not in DB. Skipping entry.")
+            insert_count["fail"] += 1
+            continue
         if attrmeta["required"] and not attrval:
             return False, f"Parameter {attrname} is a required attribute", insert_count
 

--- a/dal/licco.py
+++ b/dal/licco.py
@@ -697,7 +697,6 @@ def update_fft_in_project(prjid, fftid, fcupdate, userid,
             attrmeta = fcattrs[attrname]
         except KeyError:
             logger.debug(f"Parameter {attrname} is not in DB. Skipping entry.")
-            insert_count["fail"] += 1
             continue
         if attrmeta["required"] and not attrval:
             return False, f"Parameter {attrname} is a required attribute", insert_count


### PR DESCRIPTION
This catches leftover data from database changes and prevents erroring out if columns don't match between development project and approved project. Ignores/skips over extra columns. 