### PR TITLE
Mongomock and test refactoring

### DIFF
--- a/context.py
+++ b/context.py
@@ -1,31 +1,20 @@
 import logging
-import os
 from functools import wraps
 
-from pymongo import MongoClient
 from bson import ObjectId
 from flask import abort
 
+from dal import db_utils
 from modules.flask_authnz.flask_authnz import FlaskAuthnz, MongoDBRoles, UserGroups
 from notifications.notifier import Notifier
 
 logger = logging.getLogger(__name__)
 
-__author__ = 'mshankar@slac.stanford.edu'
-
 # Application context.
 app = None
 
-def create_mongo_client(mongodb_url: str = ""):
-    if not mongodb_url:
-        mongodb_url = os.environ.get("MONGODB_URL", None)
-        if not mongodb_url:
-            print("Please use the environment variable MONGODB_URL to configure the database connection.")
-    return MongoClient(host=mongodb_url, tz_aware=True)
-
-
 # Set up the Mongo connection.
-mongo_client = create_mongo_client()
+mongo_client = db_utils.create_mongo_client()
 licco_db = mongo_client["lineconfigdb"]
 
 

--- a/dal/db_utils.py
+++ b/dal/db_utils.py
@@ -1,0 +1,14 @@
+import logging
+import os
+
+from pymongo import MongoClient
+
+logger = logging.getLogger(__name__)
+
+def create_mongo_client(mongodb_url: str = "", timeout: int = 5000):
+    if not mongodb_url:
+        mongodb_url = os.environ.get("MONGODB_URL", None)
+
+    if not mongodb_url:
+        logger.info("Connecting to MongoDB on localhost:27017")
+    return MongoClient(host=mongodb_url, tz_aware=True, serverSelectionTimeoutMS=timeout)

--- a/dal/projdetails.py
+++ b/dal/projdetails.py
@@ -53,6 +53,10 @@ def get_project_attributes(db, projectid, fftid=None, skipClonedEntries=False, a
         # all other fields are primitive types (scalars, strings) and only the latest values are important
         details[fft_id][field_name] = field_val
 
+    if len(details) == 0:
+        # we found nothing for this set of filters, early return
+        return details
+
     # fetch and aggregate comments for all ffts
     commentFilter = {"$match": {"$and": [{"key": "discussion"}]}}
     if commentAfterTimestamp:

--- a/environment.yml
+++ b/environment.yml
@@ -38,6 +38,7 @@ dependencies:
     - markupsafe==2.1.3
     - packaging==23.2
     - pymongo==4.5.0
+    - mongomock==4.3.0
     - pytz==2023.3.post1
     - requests==2.31.0
     - urllib3==2.0.7


### PR DESCRIPTION
- Test are ran with mongomock if mongodb does not exist. We can start running them after every commit via Github actions
- Additional test case for get_ffts method call
- Tests no longer depend on context.py, and should therefore run a bit faster