### PR TITLE
Regular users see only the projects that are relevant to them

### DIFF
--- a/dal/mcd_model.py
+++ b/dal/mcd_model.py
@@ -183,7 +183,7 @@ def get_fft_values_by_project(licco_db: MongoDb, fftid, prjid):
     return fft_pairings
 
 
-def get_all_projects(licco_db: MongoDb, logged_in_user, sort_criteria):
+def get_all_projects(licco_db: MongoDb, logged_in_user, sort_criteria = None):
     """
     Return all the projects in the system.
     :return: List of projects
@@ -195,11 +195,25 @@ def get_all_projects(licco_db: MongoDb, logged_in_user, sort_criteria):
         # admin users should see all projects, hence we don't specify the filter
         pass
     else:
-        # regular user should only see projects that are visible (not hidden)
-        filter = {"status": {"$ne": "hidden"}}
+        # regular user should only see the projects that are applicable (they are owner, editor or approver)
+        # and which are visible (not hidden/deleted)
+        filter = {"status": {"$ne": "hidden"},
+                  "$and": [{
+                      "$or": [
+                          # master project should be always returned
+                          {'name': MASTER_PROJECT_NAME},
+                          {'owner': logged_in_user},
+                          {'editors': logged_in_user},
+                          {'approvers': logged_in_user},
+                      ]
+                  }]
+                  }
+
+    if not sort_criteria:
+        # order in descending order
+        sort_criteria = [["start_time", -1]]
 
     all_projects = list(licco_db["projects"].find(filter).sort(sort_criteria))
-
     return all_projects
 
 
@@ -1551,7 +1565,7 @@ def create_empty_project(licco_db: MongoDb, name, description, logged_in_user):
     return get_project(licco_db, prjid)
 
 
-def update_project_details(licco_db: MongoDb, userid, prjid, user_changes: Dict[str, any], notifier: Notifier) -> Tuple[bool, str]:
+def update_project_details(licco_db: MongoDb, userid: str, prjid: str, user_changes: Dict[str, any], notifier: Notifier) -> Tuple[bool, str]:
     """
     Just update the project name ands description
     """

--- a/tests/test_mcd_model.py
+++ b/tests/test_mcd_model.py
@@ -191,7 +191,12 @@ def test_project_filter_for_editor(db):
     project = mcd_model.create_new_project(db, "test_project_filter_for_editor", "", "test_project_filter_owner_2")
     assert project
     ok, err = mcd_model.update_project_details(db, "test_project_filter_owner_2", project["_id"],
-                                               {'editors': ["test_project_filter_editor"]}, NoOpNotifier())
+                                               {'editors': [
+                                                   # NOTE: we use multiple editors in this field to check if mongo
+                                                   # array filtering works as expected
+                                                   "test_project_filter_editor",
+                                                   "test_project_filter_editor_2"
+                                               ]}, NoOpNotifier())
     assert err == ""
     assert ok
     # get projects for the user that was chosen as editor
@@ -209,7 +214,14 @@ def test_project_filter_for_approver(db):
     # create project that should appear in result
     project = mcd_model.create_new_project(db, "test_project_filter_for_approver", "", "test_project_filter_owner_3")
     assert project
-    result = db['projects'].update_one({'_id': ObjectId(project["_id"])}, {"$set": {'editors': [], 'approvers': ['test_project_filter_approver']}})
+    result = db['projects'].update_one({'_id': ObjectId(project["_id"])}, {"$set": {
+        'editors': [],
+        # NOTE: we use multiple approvers in this field to check if mongo array filtering works as expected
+        'approvers': [
+            'test_project_filter_approver_2',
+            'test_project_filter_approver',
+        ]
+    }})
     assert result.modified_count == 1
 
     projects = mcd_model.get_all_projects(db, 'test_project_filter_approver')


### PR DESCRIPTION
Projects are shown only if you are the owner, editor or approver. Admins see every project in the db.

Might be a good idea to setup a Github action for running tests for every commit