### PR TITLE
Cleanups

### DIFF
--- a/dal/mcd_import.py
+++ b/dal/mcd_import.py
@@ -119,7 +119,7 @@ def import_project(licco_db: MongoDb, userid: str, prjid: str, csv_content: str,
     for fc_list in fcs.values():
         for fc in fc_list:
             if (fc["FC"], fc["Fungible"]) not in ffts:
-                status, errormsg, newfft = mcd_model.create_new_fft(licco_db, fc=fc["FC"], fg=fc["Fungible"], fcdesc=None, fgdesc=None)
+                status, errormsg, newfft = mcd_model.create_new_fft(licco_db, fc=fc["FC"], fg=fc["Fungible"])
                 ffts[(newfft["fc"]["name"], newfft["fg"]["name"]
                 if "fg" in newfft else None)] = newfft["_id"]
 

--- a/notifications/notifier.py
+++ b/notifications/notifier.py
@@ -88,7 +88,7 @@ class Notifier:
         return self.email_sender.validate_email(username_or_email)
 
     def add_project_editors(self, new_editor_ids: List[str], project_name: str, project_id: str):
-        subject = f"You were selected as an editor for the project {project_name}"
+        subject = f"(MCD) You were selected as an editor for the project {project_name}"
         content = create_notification_msg("add_editor", "html",
                                           project_name=project_name,
                                           project_url=self._create_project_url(project_id),
@@ -96,7 +96,7 @@ class Notifier:
         self.send_email_notification(new_editor_ids, subject, content)
 
     def remove_project_editors(self, removed_editor_ids: List[str], project_name: str, project_id: str):
-        subject = f"You were removed as an editor for the project {project_name}"
+        subject = f"(MCD) You were removed as an editor for the project {project_name}"
         content = create_notification_msg("remove_editor", "html",
                                           project_name=project_name,
                                           project_url=self._create_project_url(project_id),
@@ -104,7 +104,7 @@ class Notifier:
         self.send_email_notification(removed_editor_ids, subject, content)
 
     def add_project_approvers(self, notified_user_ids: List[str], project_name: str, project_id: str):
-        subject = f"You were selected as an approver for the project {project_name}"
+        subject = f"(MCD) You were selected as an approver for the project {project_name}"
         content = create_notification_msg("add_approver", "html",
                                           project_name=project_name,
                                           project_url=self._create_project_url(project_id),
@@ -112,7 +112,7 @@ class Notifier:
         self.send_email_notification(notified_user_ids, subject, content)
 
     def remove_project_approvers(self, notified_user_ids: List[str], project_name: str, project_id: str):
-        subject = f"You were removed from the approvers for the project {project_name}"
+        subject = f"(MCD) You were removed from the approvers for the project {project_name}"
         content = create_notification_msg("remove_approver", "html",
                                           project_name=project_name,
                                           project_url=self._create_project_url(project_id),
@@ -120,7 +120,7 @@ class Notifier:
         self.send_email_notification(notified_user_ids, subject, content)
 
     def inform_editors_of_approver_change(self, notified_user_ids: List[str], project_name: str, project_id: str, current_approvers: List[str]):
-        subject = f"Approvers have been updated for the project {project_name}"
+        subject = f"(MCD) Approvers have been updated for the project {project_name}"
         content = create_notification_msg("inform_editors_of_approver_update", "html",
                                           project_url=self._create_project_url(project_id),
                                           project_name=project_name,
@@ -129,7 +129,7 @@ class Notifier:
         self.send_email_notification(notified_user_ids, subject, content)
 
     def project_submitted_for_approval(self, notified_user_ids: List[str], project_name: str, project_id: str):
-        subject = f"Project {project_name} was submitted for approval"
+        subject = f"(MCD) Project {project_name} was submitted for approval"
         content = create_notification_msg("project_approval_submitted", "html",
                                           project_name=project_name,
                                           project_url=self._create_project_url(project_id),
@@ -137,7 +137,7 @@ class Notifier:
         self.send_email_notification(notified_user_ids, subject, content)
 
     def project_approval_approved(self, notified_user_ids: List[str], project_name: str, project_id: str):
-        subject = f"Project {project_name} was approved"
+        subject = f"(MCD) Project {project_name} was approved"
         content = create_notification_msg("project_approval_approved", "html",
                                           project_name=project_name,
                                           project_url=self._create_project_url(project_id),
@@ -146,7 +146,7 @@ class Notifier:
 
     def project_approval_rejected(self, notified_user_ids: List[str], project_name: str, project_id: str,
                                   user_who_rejected: str, reason: str):
-        subject = f"Project {project_name} was rejected"
+        subject = f"(MCD) Project {project_name} was rejected"
         content = create_notification_msg("project_approval_rejected", "html",
                                           project_name=project_name,
                                           project_url=self._create_project_url(project_id),

--- a/react/src/app/ffts/ffts_overview.tsx
+++ b/react/src/app/ffts/ffts_overview.tsx
@@ -185,9 +185,7 @@ export const AddFftDialog: React.FC<{ isOpen: boolean, ffts?: FFTInfo[], dialogT
     }, [ffts, isOpen])
 
 
-    const renderFcDescription = fcName != "" && !fcNames.has(fcName);
-    const renderFgDescription = fgName != "" && !fgNames.has(fgName);
-    const disableSubmit = fcName.trim() == "" || fgName.trim() == "" || (renderFcDescription && fcDescription.trim() == "" || renderFgDescription && fgDescription.trim() == "");
+    const disableSubmit = fcName.trim() == "" || fgName.trim() == "";
 
     const submit = () => {
         const fc = fcName.trim();
@@ -214,12 +212,6 @@ export const AddFftDialog: React.FC<{ isOpen: boolean, ffts?: FFTInfo[], dialogT
         let data: any = {
             fc: fc,
             fg: fg,
-        }
-        if (renderFcDescription) {
-            data["fc_description"] = fcDescription.trim();
-        }
-        if (renderFgDescription) {
-            data["fg_description"] = fgDescription.trim();
         }
 
         setIsSubmitting(true);
@@ -270,30 +262,12 @@ export const AddFftDialog: React.FC<{ isOpen: boolean, ffts?: FFTInfo[], dialogT
                                 onValueChange={(val: string) => setFcName(val)} />
                         </FormGroup>
 
-                        <FormGroup label="FC Description:" labelInfo="(required)" labelFor="fc-description"
-                            disabled={!renderFcDescription}>
-                            <InputGroup id="fc-description"
-                                disabled={!renderFcDescription}
-                                value={fcDescription}
-                                onValueChange={(val: string) => setFcDescription(val)}
-                            />
-                        </FormGroup>
-
                         <FormGroup label="Fungible Token:" labelFor="fg-name" className="mt-4">
                             <InputGroup id="fg-name"
                                 list="fg-names-list"
                                 rightElement={<Icon className="ps-2 pe-2" icon="caret-down" color={Colors.GRAY1} />}
                                 value={fgName}
                                 onValueChange={(val: string) => setFgName(val)} />
-                        </FormGroup>
-
-                        <FormGroup label="FG Description:" labelInfo="(required)" labelFor="fg-description"
-                            disabled={!renderFgDescription}>
-                            <InputGroup id="fg-description"
-                                disabled={!renderFgDescription}
-                                value={fgDescription}
-                                onValueChange={(val: string) => setFgDescription(val)}
-                            />
                         </FormGroup>
                     </>
                 }

--- a/react/src/app/projects/[projectId]/project_details.tsx
+++ b/react/src/app/projects/[projectId]/project_details.tsx
@@ -288,6 +288,7 @@ export const ProjectDetails: React.FC<{ projectId: string }> = ({ projectId }) =
         return data;
     }
 
+    const isProjectApproved = project && project.name == MASTER_PROJECT_NAME;
     const isProjectInDevelopment = project && project.name !== MASTER_PROJECT_NAME && project.status === "development";
     const isFilterApplied = fcFilter != "" || fgFilter != "" || stateFilter != "";
     const isRemoveFilterEnabled = isFilterApplied || showFftSinceCreationFilter || asOfTimestampFilter;
@@ -396,16 +397,18 @@ export const ProjectDetails: React.FC<{ projectId: string }> = ({ projectId }) =
                                         />
 
                                         <Divider />
-
-                                        <Button icon="tag-add" title="Create a snapshot" minimal={true} small={true}
-                                            disabled={disableActionButtons}
-                                            onClick={(e) => { setIsTagCreationDialogOpen(true) }}
-                                        />
-                                        <Button icon="tags" title="Show created snapshots" minimal={true} small={true}
-                                            onClick={(e) => { setIsTagSelectionDialogOpen(true) }}
-                                        />
-                                        <Divider />
-
+                                        {isProjectApproved ?
+                                            <>
+                                                <Button icon="tag-add" title="Create a snapshot" minimal={true} small={true}
+                                                    onClick={(e) => { setIsTagCreationDialogOpen(true) }}
+                                                />
+                                                <Button icon="tags" title="Show created snapshots" minimal={true} small={true}
+                                                    onClick={(e) => { setIsTagSelectionDialogOpen(true) }}
+                                                />
+                                                <Divider />
+                                            </>
+                                            : null
+                                        }
                                         <Button icon="history" title="Show the history of changes" minimal={true} small={true}
                                             intent={asOfTimestampFilter ? "danger" : "none"}
                                             onClick={(e) => setIsProjectHistoryDialogOpen(true)}
@@ -638,7 +641,7 @@ export const ProjectDetails: React.FC<{ projectId: string }> = ({ projectId }) =
                     }}
                 />
                 : null}
-            {project ?
+            {project && isProjectApproved ?
                 <SnapshotSelectionDialog
                     isOpen={isTagSelectionDialogOpen}
                     projectId={project._id}
@@ -651,7 +654,7 @@ export const ProjectDetails: React.FC<{ projectId: string }> = ({ projectId }) =
                     onClose={() => setIsTagSelectionDialogOpen(false)}
                 />
                 : null}
-            {project ?
+            {project && isProjectApproved ?
                 <SnapshotCreationDialog
                     isOpen={isTagCreationDialogOpen}
                     projectId={project._id}
@@ -885,7 +888,7 @@ const DeviceDataEditTableRow: React.FC<{
                     continue;
                 }
 
-            // field has changed
+                // field has changed
                 if (field === "state") {
                     // we have to transform the state from what's displayed into an enum that
                     // a backend understands, hence this transformation

--- a/react/src/app/utils/fetching.ts
+++ b/react/src/app/utils/fetching.ts
@@ -100,7 +100,7 @@ export class Fetch {
             if (response.status == NO_CONTENT) {
                 // sometimes the response will be empty (usually a delete respone) in which case
                 // we don't have anything to return but undefined to satisfy the generic type T
-                let t: T;
+                const t = undefined as T;
                 return new Promise(ok => ok(t));
             }
 

--- a/runscripts/rolesHelper.py
+++ b/runscripts/rolesHelper.py
@@ -1,0 +1,35 @@
+from dal import db_utils
+
+# Set up the Mongo connection.
+mongo_client = db_utils.create_mongo_client()
+licco_db = mongo_client["lineconfigdb"]
+
+# create admins
+licco_db["roles"].insert_one({
+    "app": "Licco", 
+    "name": "admin",
+    "privileges" : [
+        "read",
+        "write",
+        "edit",
+        "approve"
+    ],
+    "players" : [
+        "uid:xxxxxx"
+    ]
+    })
+
+# create supperapprovers
+licco_db["roles"].insert_one({
+    "app" : "Licco",
+    "name" : "superapprover",
+    "privileges" : [
+        "read",
+        "approve"
+    ],
+    "players" : [
+        "uid:yyyyy"
+    ]
+    })
+
+

--- a/services/licco.py
+++ b/services/licco.py
@@ -109,7 +109,7 @@ def svc_get_users():
         elif role == "approvers":
             users["approvers"] = mcd_model.get_users_with_privilege(licco_db, "approve")
         elif role == "super_approvers":
-            users["super_approvers"] = mcd_model.get_users_with_privilege(licco_db, "super_approve")
+            users["super_approvers"] = mcd_model.get_users_with_privilege(licco_db, "superapprover")
         else:
             return json_error(f"invalid user role '{role}'")
 
@@ -336,9 +336,7 @@ def svc_create_fft():
     For now, we expect the ID's of the functional component and the fungible token ( and not the names )
     """
     newfft = request.json
-    status, errormsg, fft = mcd_model.create_new_fft(licco_db, fc=newfft["fc"], fg=newfft["fg"],
-                                                     fcdesc=newfft.get("fc_description", None),
-                                                     fgdesc=newfft.get("fg_description", None))
+    status, errormsg, fft = mcd_model.create_new_fft(licco_db, fc=newfft["fc"], fg=newfft["fg"])
     if errormsg:
         return json_error(errormsg)
     return json_response(fft)

--- a/tests/test_mcd_model.py
+++ b/tests/test_mcd_model.py
@@ -61,9 +61,9 @@ def db():
     assert len(res.inserted_ids) == 4, "roles should be inserted"
 
     # ffts used in tests
-    ffts = [{"fc": "TESTFC", "fc_desc": "fcDesc", "fg": "TESTFG", "fg_desc": "fgDesc"}]
+    ffts = [{"fc": "TESTFC", "fg": "TESTFG"}]
     for f in ffts:
-        ok, err, fft = mcd_model.create_new_fft(db, f['fc'], f['fg'], f.get('fc_desc', ''), f.get('fg_desc', ''))
+        ok, err, fft = mcd_model.create_new_fft(db, f['fc'], f['fg'])
         assert ok, f"fft '{f['fc']}' could not be inserted due to: {err}"
 
     return db


### PR DESCRIPTION
- Hides tag(snapshot) buttons for all projects besides Approved Project
- Enables tag/snapshot creation for Approved project
- Removes ability to add in FC/FG descriptions upon creation, and adds filler data
- Some cleanup for admins/super approvers, including a standalone script to run and add in initial user types
- Add in (MCD) prefix to start all emails-Subject lines should have the tool name
- Fix small declaration bug in fetching that errored