### PR TITLE
FG Update and Approver email bug fix

### DIFF
--- a/dal/mcd_model.py
+++ b/dal/mcd_model.py
@@ -29,7 +29,8 @@ McdProject: TypeAlias = Dict[str, any]
 KEYMAP = {
     # Column names defined in confluence
     "FC": "fc",
-    "Fungible": "fg",
+    "FG": "fg",
+    "Fungible": "fg_desc",
     "TC_part_no": "tc_part_no",
     "Stand": "stand",
     "State": "state",
@@ -104,8 +105,8 @@ def initialize_collections(licco_db: MongoDb):
     master_project = licco_db["projects"].find_one({"name": MASTER_PROJECT_NAME})
     if not master_project:
         prj = create_new_project(licco_db, MASTER_PROJECT_NAME, "Master Project", '')
-        # initial status is set to development, so we can avoid displaying it on the frontend
-        licco_db["projects"].update_one({"_id": prj["_id"]}, {"$set": {"status": "development"}})
+        # initial status is set to approved
+        licco_db["projects"].update_one({"_id": prj["_id"]}, {"$set": {"status": "approved"}})
 
 
 def is_user_allowed_to_edit_project(userid: str, project: Dict[str, any]) -> bool:
@@ -301,9 +302,7 @@ def get_fgs(licco_db: MongoDb):
     fgs_used = set(licco_db["ffts"].distinct("fg"))
     for fg in fgs:
         fg["is_being_used"] = fg["_id"] in fgs_used
-
     return fgs
-
 
 def delete_fg(licco_db: MongoDb, fgid):
     """
@@ -475,12 +474,8 @@ def create_new_fft(licco_db: MongoDb, fc, fg, fcdesc="Default", fgdesc="Default"
     Create a new functional component + fungible token based on their names
     If the FC or FG don't exist; these are created if the associated descriptions are also passed in.
     """
-    if empty_string_or_none(fc) or empty_string_or_none(fg):
-        err = "can't create a new fft"
-        if empty_string_or_none(fc):
-            err += ": FC can't be empty"
-        if empty_string_or_none(fg):
-            err += ": FG can't be empty"
+    if empty_string_or_none(fc):
+        err = "can't create a new fft: FC can't be empty"
         return False, err, None
 
     logger.info("Creating new fft with %s and %s", fc, fg)
@@ -538,6 +533,14 @@ def str2int(val):
 # We could perhaps use dataclasses here but we're not really storing the document as it is.
 # So, let's try explicit metadata for the fc attrs
 fcattrs = {
+    "fg_desc": {
+        "name": "fg_desc",
+        "type": "text",
+        "fromstr": str,
+        "label": "Fungible",
+        "desc": "Fungible_user",
+        "required": False
+    },
     "tc_part_no": {
         "name": "tc_part_no",
         "type": "text",
@@ -1197,29 +1200,28 @@ def submit_project_for_approval(licco_db: MongoDb, project_id: str, userid: str,
 
     # send notifications (to the right approvers and project editors)
     old_approvers = prj.get("approvers", [])
-    diff = diff_arrays(old_approvers, approvers)
+    update_diff = diff_arrays(old_approvers, approvers)
+    superapp_diff = diff_arrays(super_approvers, approvers)
 
-    new_approvers = diff.new
-    if new_approvers:
-        # split out superapprovers, we email them later
-        new_regular_approvers = set(new_approvers) - set(super_approvers)
-        if new_regular_approvers:
-            notifier.add_project_approvers(list(new_regular_approvers), project_name, project_id)
-
-    deleted_approvers = diff.removed
+    deleted_approvers = update_diff.removed
     if deleted_approvers:
         notifier.remove_project_approvers(deleted_approvers, project_name, project_id)
 
     if prj["status"] == "development":
         # project was submitted for the first time
         project_editors = list(set([prj["owner"]] + editors))
+        # inform all editors, super approvers, and approvers
         notifier.project_submitted_for_approval(project_editors, project_name, project_id)
-        notifier.add_project_superapprovers(super_approvers, project_name, project_id)
+        notifier.add_project_superapprovers(list(superapp_diff.in_both), project_name, project_id)
+        notifier.add_project_approvers(list(superapp_diff.new), project_name, project_id)
 
     else:
         # project was edited
+        if update_diff.new:
+            # update any new approvers
+            notifier.add_project_approvers(list(update_diff.new), project_name, project_id)
         project_editors = list(set([prj["owner"]] + editors))
-        approvers_have_changed = new_approvers or deleted_approvers
+        approvers_have_changed = update_diff.new or deleted_approvers
         if approvers_have_changed:
             notifier.inform_editors_of_approver_change(project_editors, project_name, project_id, approvers)
 
@@ -1544,31 +1546,34 @@ def clone_project(licco_db: MongoDb, userid: str, prjid: str, name: str, descrip
     myfcs = get_project_attributes(licco_db, prjid)
     modification_time = created_project["creation_time"]
     all_inserts = []
-    for fftid, attrs in myfcs.items():
-        del attrs["fft"]
-        for attrname, attrval in attrs.items():
-            if attrname == "discussion":
-                # when cloning a project, we also want to clone all the comments
-                # discussion is returned as an array and therefore needs special handling
-                for comment in attrval:
+
+    # Check for valid content, and copy over present data
+    if myfcs.items():
+        for fftid, attrs in myfcs.items():
+            del attrs["fft"]
+            for attrname, attrval in attrs.items():
+                if attrname == "discussion":
+                    # when cloning a project, we also want to clone all the comments
+                    # discussion is returned as an array and therefore needs special handling
+                    for comment in attrval:
+                        all_inserts.append({
+                            "prj": created_project["_id"],
+                            "fft": ObjectId(fftid),
+                            "key": attrname,
+                            "val": comment['comment'],
+                            "user": comment['author'],
+                            "time": modification_time,
+                        })
+                else:
                     all_inserts.append({
                         "prj": created_project["_id"],
                         "fft": ObjectId(fftid),
                         "key": attrname,
-                        "val": comment['comment'],
-                        "user": comment['author'],
-                        "time": modification_time,
+                        "val": attrval,
+                        "user": userid,
+                        "time": modification_time
                     })
-            else:
-                all_inserts.append({
-                    "prj": created_project["_id"],
-                    "fft": ObjectId(fftid),
-                    "key": attrname,
-                    "val": attrval,
-                    "user": userid,
-                    "time": modification_time
-                })
-    licco_db["projects_history"].insert_many(all_inserts)
+        licco_db["projects_history"].insert_many(all_inserts)
 
     if editors:
         status, err = update_project_details(licco_db, userid, created_project["_id"], {'editors': editors}, notifier)

--- a/notifications/notifier.py
+++ b/notifications/notifier.py
@@ -35,20 +35,20 @@ _NOTIFICATION_TEMPLATES = {
     "project_approval_submitted": {
         "html": inspect.cleandoc("""
         <p>Automated Message - Please Do Not Reply</p>
-        <p>Your project <a href="{project_url}">{project_name}</a> in the Machine Configuration Database have been submitted to approval.</p>
+        <p>The project <a href="{project_url}">{project_name}</a> in the Machine Configuration Database has been submitted for approval.</p>
         <p>If you have any questions, please contact the database administrator at {admin_email}.</p>""")
     },
     "project_approval_rejected": {
         "html": inspect.cleandoc("""
         <p>Automated Message - Please Do Not Reply</p>
-        <p>Your project <a href="{project_url}">{project_name}</a> in the Machine Configuration Database have been rejected by {user_who_rejected}.<br/>Reason:</p>
+        <p>The project <a href="{project_url}">{project_name}</a> in the Machine Configuration Database has been rejected by {user_who_rejected}.<br/>Reason:</p>
         <p>{reason}</p>
         <p>If you have any questions, please contact the database administrator at {admin_email}.</p>""")
     },
     "project_approval_approved": {
         "html": inspect.cleandoc("""
         <p>Automated Message - Please Do Not Reply</p>
-        <p>Your project <a href="{project_url}">{project_name}</a> in the Machine Configuration Database have been approved.</p>
+        <p>The project <a href="{project_url}">{project_name}</a> in the Machine Configuration Database has been approved.</p>
         <p>If you have any questions, please contact the database administrator at {admin_email}.</p>""")
     },
     "add_editor": {
@@ -113,7 +113,7 @@ class Notifier:
         subject = f"(MCD) You were selected as an approver for the project {project_name}"
         content = create_notification_msg("add_approver", "html",
                                           project_name=project_name,
-                                          project_url=self._create_project_url(project_id),
+                                          project_url=self._create_approval_url(project_id),
                                           admin_email=self.admin_email)
         self.send_email_notification(notified_user_ids, subject, content)
 
@@ -121,7 +121,7 @@ class Notifier:
         subject = f"(MCD) You were added as a Super Approver for the project {project_name}"
         content = create_notification_msg("add_superapprover", "html",
                                           project_name=project_name,
-                                          project_url=self._create_project_url(project_id),
+                                          project_url=self._create_approval_url(project_id),
                                           admin_email=self.admin_email)
         self.send_email_notification(notified_user_ids, subject, content)
 
@@ -189,3 +189,6 @@ class Notifier:
 
     def _create_project_url(self, project_id: str):
         return f"{self.licco_service_url}/projects/{project_id}"
+    
+    def _create_approval_url(self, project_id: str):
+        return self._create_project_url(project_id) + '/approval/'

--- a/react/src/app/components/navbar.tsx
+++ b/react/src/app/components/navbar.tsx
@@ -2,13 +2,12 @@
 
 import { Alignment, AnchorButton, Navbar } from '@blueprintjs/core';
 import { usePathname } from 'next/navigation';
-import { Anchor } from 'react-bootstrap';
+import { Anchor, NavbarBrand } from 'react-bootstrap';
 import styles from './navbar.module.css';
 import { createLink } from "@/app/utils/path_utils";
 
 const links = [
     { link: createLink('/'), label: 'Projects' },
-    { link: createLink('/ffts'), label: 'FFTs' },
 ];
 
 export function Navigation() {
@@ -20,16 +19,16 @@ export function Navigation() {
         return `${styles.btn} bp5-minimal`;
     }
 
-    
+
 
     return (
         <Navbar className={styles.navbar}>
             <Navbar.Group align={Alignment.LEFT}>
                 <Navbar.Heading>
-                    <Anchor href={createLink("/")} style={{ fontSize: "1.3rem", textDecoration: "none", fontWeight: "bold" }}>
+                    <NavbarBrand style={{ fontSize: "1.3rem", textDecoration: "none", fontWeight: "bold" }}>
                         {/* <img className={styles.logo} src="/assets/licco-logo.png" alt="Licco logo" /> */}
                         Machine Configuration Database
-                    </Anchor>
+                    </NavbarBrand>
                 </Navbar.Heading>
             </Navbar.Group>
             <Navbar.Group align={Alignment.LEFT}>

--- a/react/src/app/ffts/ffts_overview.tsx
+++ b/react/src/app/ffts/ffts_overview.tsx
@@ -130,31 +130,20 @@ export const AddFftDialog: React.FC<{ isOpen: boolean, ffts?: FFTInfo[], dialogT
     const [isLoading, setIsLoading] = useState(false);
     const [isSubmitting, setIsSubmitting] = useState(false);
 
-
     const [fcNames, setFcNames] = useState<Set<string>>(new Set());
-    const [fcDescription, setFcDescription] = useState('');
-
-    const [fgNames, setFgNames] = useState<Set<string>>(new Set());
-    const [fgDescription, setFgDescription] = useState('');
 
     const createFgFcNames = (ffts: FFTInfo[]) => {
         let fcSet = new Set<string>();
-        let fgSet = new Set<string>();
 
         for (let fft of ffts) {
             let fcName = fft.fc.name;
             if (fcName != "") {
                 fcSet.add(fcName);
             }
-
-            let fgName = fft.fg.name;
-            if (fgName != "") {
-                fgSet.add(fgName);
-            }
         }
 
         setFcNames(fcSet);
-        setFgNames(fgSet);
+        setFgName('');
     }
 
     useEffect(() => {
@@ -185,7 +174,7 @@ export const AddFftDialog: React.FC<{ isOpen: boolean, ffts?: FFTInfo[], dialogT
     }, [ffts, isOpen])
 
 
-    const disableSubmit = fcName.trim() == "" || fgName.trim() == "";
+    const disableSubmit = fcName.trim() == "";
 
     const submit = () => {
         const fc = fcName.trim();
@@ -230,10 +219,9 @@ export const AddFftDialog: React.FC<{ isOpen: boolean, ffts?: FFTInfo[], dialogT
     return (
         <Dialog isOpen={isOpen} onClose={onClose} title="Add a new FFT" autoFocus={true} style={{ width: "70ch" }}>
             <DialogBody useOverflowScrollContainer>
-                <p>Please choose/enter a functional component name and fungible token.
-                    You can choose one of the existing entities or you can type in a brand new functional component name or fungible token.
+                <p>Please choose/enter a functional component name.
+                    You can choose one of the existing entities or you can type in a brand new functional component name.
                 </p>
-                <p>If either entity does not exist in the system, description inputs will be enabled. Please enter a valid description; and these will be automatically created in the system for you as part of creating the new FFT.</p>
 
                 {isLoading ?
                     <NonIdealState icon={<Spinner />} title="Loading" description="Please Wait..." />
@@ -246,12 +234,6 @@ export const AddFftDialog: React.FC<{ isOpen: boolean, ffts?: FFTInfo[], dialogT
                             }
                         </datalist>
 
-                        <datalist id="fg-names-list">
-                            {Array.from(fgNames.values()).sort((a, b) => sortString(a, b, false)).map(name => {
-                                return <option key={name} value={name} />
-                            })
-                            }
-                        </datalist>
                         <FormGroup label="Functional Component:" labelFor="fc-name">
                             <InputGroup id="fc-name"
                                 autoFocus={true}
@@ -262,13 +244,6 @@ export const AddFftDialog: React.FC<{ isOpen: boolean, ffts?: FFTInfo[], dialogT
                                 onValueChange={(val: string) => setFcName(val)} />
                         </FormGroup>
 
-                        <FormGroup label="Fungible Token:" labelFor="fg-name" className="mt-4">
-                            <InputGroup id="fg-name"
-                                list="fg-names-list"
-                                rightElement={<Icon className="ps-2 pe-2" icon="caret-down" color={Colors.GRAY1} />}
-                                value={fgName}
-                                onValueChange={(val: string) => setFgName(val)} />
-                        </FormGroup>
                     </>
                 }
 

--- a/react/src/app/projects/[projectId]/diff/project_diff.tsx
+++ b/react/src/app/projects/[projectId]/diff/project_diff.tsx
@@ -161,7 +161,7 @@ export const ProjectDiffTable: React.FC<{ diff: ProjectFftDiff, user: string, ty
         return data.map(devices => {
             return (<tr key={devices.a.id}>
                 <td>{renderField(devices.a, devices.b, 'fc')}</td>
-                <td>{renderField(devices.a, devices.b, 'fg')}</td>
+                <td>{renderField(devices.a, devices.b, 'fg_desc')}</td>
                 <td>{renderField(devices.a, devices.b, 'tc_part_no')}</td>
                 <td>{renderField(devices.a, devices.b, 'stand')}</td>
                 <td>{renderField(devices.a, devices.b, 'state')}</td>
@@ -189,7 +189,7 @@ export const ProjectDiffTable: React.FC<{ diff: ProjectFftDiff, user: string, ty
             return (
                 <tr key={d.id}>
                     <td>{d.fc}</td>
-                    <td>{d.fg}</td>
+                    <td>{d.fg_desc}</td>
                     <td>{d.tc_part_no}</td>
                     <td>{d.stand}</td>
                     <td>{d.state}</td>

--- a/react/src/app/projects/[projectId]/project_details.tsx
+++ b/react/src/app/projects/[projectId]/project_details.tsx
@@ -33,12 +33,12 @@ export function sortDeviceDataByColumn(data: ProjectDeviceDetails[], col: device
                 if (diff != 0) {
                     return diff;
                 }
-                return sortString(a.fg, b.fg, false); // asc 
+                return sortString(a.fg_desc, b.fg_desc, false); // asc 
             });
             break;
         case "fg":
             data.sort((a, b) => {
-                let diff = sortString(a.fg, b.fg, desc);
+                let diff = sortString(a.fg_desc, b.fg_desc, desc);
                 if (diff != 0) {
                     return diff;
                 }
@@ -148,7 +148,7 @@ export const ProjectDetails: React.FC<{ projectId: string }> = ({ projectId }) =
         {
             // set filters based on query params
             setFcFilter(queryParams.get("fc") ?? "");
-            setFgFilter(queryParams.get("fg") ?? "");
+            setFgFilter(queryParams.get("fg_desc") ?? "");
             setStateFilter(queryParams.get("state") ?? "");
             setAsOfTimestampFilter(queryParams.get("asoftimestamp") ?? "");
         }
@@ -190,7 +190,7 @@ export const ProjectDetails: React.FC<{ projectId: string }> = ({ projectId }) =
             return true;
         }).filter(d => {
             if (fgFilter) {
-                return fgGlobMatcher.test(d.fg);
+                return fgGlobMatcher.test(d.fg_desc);
             }
             return true;
         }).filter(d => {
@@ -247,7 +247,7 @@ export const ProjectDetails: React.FC<{ projectId: string }> = ({ projectId }) =
         // if it does, simply show an error message to the user
         for (let fft of fftData) {
             if (fft.fc === newFft.fc.name && fft.fg === newFft.fg.name) {
-                setErrorAlertMsg(<>FFT <b>{fft.fc}-{fft.fg}</b> is already a part of the project: "{project.name}".</>);
+                setErrorAlertMsg(<>FC <b>{fft.fc}</b> is already a part of the project: "{project.name}".</>);
                 return
             }
         }
@@ -283,7 +283,7 @@ export const ProjectDetails: React.FC<{ projectId: string }> = ({ projectId }) =
         // create the csv document from filtered devices
         let data = `FC,Fungible,TC_part_no,Stand,State,LCLS_Z_loc,LCLS_X_loc,LCLS_Y_loc,LCLS_Z_roll,LCLS_X_pitch,LCLS_Y_yaw,Must_Ray_Trace,Comments\n`;
         for (let device of devices) {
-            data += `${r(device.fc)},${r(device.fg)},${r(device.tc_part_no)},${r(device.stand)},${r(device.state)},${r(device.nom_loc_z)},${r(device.nom_loc_x)},${r(device.nom_loc_y)},${r(device.nom_ang_z)},${r(device.nom_ang_x)},${r(device.nom_ang_y)},${r(device.ray_trace)},${r(device.comments)}\n`;
+            data += `${r(device.fc)},${r(device.fg_desc)},${r(device.tc_part_no)},${r(device.stand)},${r(device.state)},${r(device.nom_loc_z)},${r(device.nom_loc_x)},${r(device.nom_loc_y)},${r(device.nom_ang_z)},${r(device.nom_ang_x)},${r(device.nom_ang_y)},${r(device.ray_trace)},${r(device.comments)}\n`;
         }
         return data;
     }
@@ -440,7 +440,7 @@ export const ProjectDetails: React.FC<{ projectId: string }> = ({ projectId }) =
                         <tr>
                             {isProjectInDevelopment ? <th></th> : null}
                             <th onClick={e => changeSortOrder('fc')}>FC {displayFilterIconInColumn(fcFilter)}{displaySortOrderIconInColumn('fc')}</th>
-                            <th onClick={e => changeSortOrder('fg')}>Fungible {displayFilterIconInColumn(fgFilter)}{displaySortOrderIconInColumn('fg')}</th>
+                            <th onClick={e => changeSortOrder('fg_desc')}>Fungible {displayFilterIconInColumn(fgFilter)}{displaySortOrderIconInColumn('fg_desc')}</th>
                             <th onClick={e => changeSortOrder('tc_part_no')}>TC Part No. {displaySortOrderIconInColumn('tc_part_no')}</th>
                             <th onClick={e => changeSortOrder('stand')}>Stand/Nearest Stand {displayFilterIconInColumn(stateFilter)} {displaySortOrderIconInColumn('stand')}</th>
                             <th onClick={e => changeSortOrder('state')}>State {displayFilterIconInColumn(stateFilter)} {displaySortOrderIconInColumn('state')}</th>
@@ -728,7 +728,7 @@ const DeviceDataTableRow: React.FC<{ project?: ProjectInfo, device: ProjectDevic
                                 <Button icon="edit" minimal={true} small={true} title="Edit this FFT"
                                     onClick={(e) => onEdit(device)}
                                 />
-                                <Button icon="refresh" minimal={true} small={true} title={"Copy over the value from the currently approved project"}
+                                <Button icon="refresh" minimal={true} small={true} title={"Copy over the value from another project"}
                                     onClick={(e) => onCopyFft(device)}
                                 />
                                 <Button icon="trash" minimal={true} small={true} title={"Delete this device"}
@@ -746,7 +746,7 @@ const DeviceDataTableRow: React.FC<{ project?: ProjectInfo, device: ProjectDevic
                 }
 
                 <td>{device.fc}</td>
-                <td>{device.fg}</td>
+                <td>{device.fg_desc}</td>
                 <td>{device.tc_part_no}</td>
                 <td>{device.stand}</td>
                 <td>{device.state}</td>
@@ -798,7 +798,7 @@ const DeviceDataEditTableRow: React.FC<{
 
     const editableDeviceFields: EditField[] = [
         { key: 'fc', type: "string", value: useState<string>(), err: useState(false) },
-        { key: 'fg', type: "string", value: useState<string>(), err: useState(false) },
+        { key: 'fg_desc', type: "string", value: useState<string>(), err: useState(false) },
         { key: 'tc_part_no', type: "string", value: useState<string>(), err: useState(false) },
         { key: 'stand', type: "string", value: useState<string>(), err: useState(false) },
         { key: 'state', type: "select", valueOptions: fftStates, value: useState<string>(), err: useState(false) },

--- a/react/src/app/projects/[projectId]/project_dialogs.tsx
+++ b/react/src/app/projects/[projectId]/project_dialogs.tsx
@@ -633,7 +633,7 @@ export const SnapshotSelectionDialog: React.FC<{
 
 // sort project value changes according to the order in which device fields appear in the device table
 const sortProjectValueChanges = (changes: Record<string, any>) => {
-  let order: (keyof ProjectDeviceDetails)[] = ['fc', 'fg', 'tc_part_no', 'stand', 'state', 'comments', 'nom_loc_z', 'nom_loc_x', 'nom_loc_y', 'nom_ang_z', 'nom_ang_x', 'nom_ang_y', 'ray_trace'];
+  let order: (keyof ProjectDeviceDetails)[] = ['fc', 'fg', 'fg_desc', 'tc_part_no', 'stand', 'state', 'comments', 'nom_loc_z', 'nom_loc_x', 'nom_loc_y', 'nom_ang_z', 'nom_ang_x', 'nom_ang_y', 'ray_trace'];
   let sortOrder: Record<any, number> = {};
   for (let i = 0; i < order.length; i++) {
     sortOrder[order[i]] = i;
@@ -808,7 +808,7 @@ export const FFTCommentViewerDialog: React.FC<{ isOpen: boolean, project: Projec
     <Dialog isOpen={isOpen} onClose={onClose} title={`Comments for ${device.fc}-${device.fg}`} autoFocus={true} style={{ width: "75ch", maxWidth: "95%" }}>
       <DialogBody useOverflowScrollContainer>
 
-        {isUserAProjectEditor(project, user) || isUserAProjectApprover(project, user) ? 
+        {isUserAProjectEditor(project, user) || isUserAProjectApprover(project, user) ?
           <FormGroup label="Add a comment:">
             <TextArea autoFocus={true} fill={true} onChange={e => setComment(e.target.value)} value={comment} placeholder="Comment text..." rows={4} />
 

--- a/react/src/app/projects/project_model.tsx
+++ b/react/src/app/projects/project_model.tsx
@@ -201,6 +201,7 @@ export function deviceDetailsBackendToFrontend(details: ProjectDeviceDetailsBack
 }
 
 export interface deviceDetailFields {
+    fg_desc: string,
     tc_part_no: string;
     comments: string;
     stand: string,

--- a/runscripts/data/export_template.csv
+++ b/runscripts/data/export_template.csv
@@ -1,1 +1,1 @@
-FC,Fungible,TC_part_no,State,Comments,LCLS_Z_loc,LCLS_X_loc,LCLS_Y_loc,Z_dim,X_dim,Y_dim,LCLS_Z_roll,LCLS_X_pitch,LCLS_Y_yaw,Must_Ray_Trace
+FC,Fungible,TC_part_no,Stand,State,LCLS_Z_loc,LCLS_X_loc,LCLS_Y_loc,LCLS_Z_roll,LCLS_X_pitch,LCLS_Y_yaw,Must_Ray_Trace,Comments

--- a/tests/test_mcd_model.py
+++ b/tests/test_mcd_model.py
@@ -375,7 +375,7 @@ def test_project_approval_workflow(db):
     assert len(email_sender.emails_sent) == 1, "Editor should receive a notification that they were appointed"
     editor_mail = email_sender.emails_sent[0]
     assert editor_mail['to'] == ['editor_user', 'editor_user_2']
-    assert editor_mail['subject'] == 'You were selected as an editor for the project test_approval_workflow'
+    assert editor_mail['subject'] == '(MCD) You were selected as an editor for the project test_approval_workflow'
     email_sender.clear()
 
     # an editor user should be able to save an fft
@@ -403,12 +403,12 @@ def test_project_approval_workflow(db):
     assert len(email_sender.emails_sent) == 2, "wrong number of notification emails sent"
     approver_email = email_sender.emails_sent[0]
     assert approver_email['to'] == ['approve_user', 'super_approver']
-    assert approver_email['subject'] == "You were selected as an approver for the project test_approval_workflow"
+    assert approver_email['subject'] == "(MCD) You were selected as an approver for the project test_approval_workflow"
 
     # this project was submitted for the first time, therefore an initial message should be sent to editors
     editor_email = email_sender.emails_sent[1]
     assert editor_email['to'] == ["editor_user", "editor_user_2", "test_user"]
-    assert editor_email['subject'] == "Project test_approval_workflow was submitted for approval"
+    assert editor_email['subject'] == "(MCD) Project test_approval_workflow was submitted for approval"
     email_sender.clear()
 
     project = mcd_model.get_project(db, prjid)
@@ -443,7 +443,7 @@ def test_project_approval_workflow(db):
     assert len(email_sender.emails_sent) == 1, "only one set of messages should be sent"
     email = email_sender.emails_sent[0]
     assert email['to'] == ['approve_user', 'editor_user', 'editor_user_2', 'super_approver', 'test_user']
-    assert email['subject'] == 'Project test_approval_workflow was approved'
+    assert email['subject'] == '(MCD) Project test_approval_workflow was approved'
     email_sender.clear()
 
 
@@ -486,7 +486,7 @@ def test_project_rejection(db):
     assert len(email_sender.emails_sent) == 1
     email = email_sender.emails_sent[0]
     assert email['to'] == ['approve_user', 'approve_user_2', 'editor_user', 'editor_user_2', 'super_approver', 'test_user']
-    assert email['subject'] == 'Project test_project_rejection_workflow was rejected'
+    assert email['subject'] == '(MCD) Project test_project_rejection_workflow was rejected'
     assert 'This is my rejection message' in email['content']
 
 
@@ -515,7 +515,7 @@ Machine Config Database,,,
 
 FC,Fungible,TC_part_no,Stand,State,Comments,LCLS_Z_loc,LCLS_X_loc,LCLS_Y_loc,LCLS_Z_roll,LCLS_X_pitch,LCLS_Y_yaw,Must_Ray_Trace
 AT1L0,COMBO,12324,SOME_TEST_STAND,Conceptual,TEST,1.21,0.21,2.213,1.231,,,
-AT1L0,GAS,3213221,,Conceptual,GAS ATTENUATOR,,,,1.23,-1.25,-0.895304,1
+AT2L0,GAS,3213221,,Conceptual,GAS ATTENUATOR,,,,1.23,-1.25,-0.895304,1
 """
 
     with io.StringIO() as stream:
@@ -538,32 +538,32 @@ AT1L0,GAS,3213221,,Conceptual,GAS ATTENUATOR,,,,1.23,-1.25,-0.895304,1
         assert len(ffts) == 2, "There should be 2 ffts inserted into a project"
 
         expected_ffts = {
-            'COMBO': {'fc': 'AT1L0', 'fg': 'COMBO', 'tc_part_no': '12324', 'stand': 'SOME_TEST_STAND',
+            'COMBO': {'fc': 'AT1L0', 'fg':'', 'fg_desc': 'COMBO', 'tc_part_no': '12324', 'stand': 'SOME_TEST_STAND',
                       'state': 'Conceptual', 'comments': 'TEST',
                       'nom_loc_z': 1.21, 'nom_loc_x': 0.21, 'nom_loc_y': 2.213, 'nom_ang_z': 1.231},
-            'GAS': {'fc': 'AT1L0', 'fg': 'GAS', 'tc_part_no': '3213221',
+            'GAS': {'fc': 'AT2L0', 'fg': '', 'fg_desc': 'GAS', 'tc_part_no': '3213221',
                     'state': 'Conceptual', 'comments': 'GAS ATTENUATOR',
                     'nom_ang_z': 1.23, 'nom_ang_x': -1.25, 'nom_ang_y': -0.895304, 'ray_trace': 1},
         }
 
-        # convert received ffts into a format that we can compare (fgs are unique)
+        # convert received ffts into a format that we can compare
         got_ffts = {}
         for _, f in ffts.items():
             fc = f['fft']['fc']
             fg = f['fft']['fg']
             f['fc'] = fc
             f['fg'] = fg
-            got_ffts[fg] = f
+            got_ffts[fc] = f
 
         # assert fft values
         for expected in expected_ffts.values():
-            fg = expected['fg']
-            assert fg in got_ffts, f"{expected['fg']} fg was not found in ffts: fft was not inserted correctly"
-            got = got_ffts[fg]
+            fc = expected['fc']
+            assert fc in got_ffts, f"{expected['fc']} fc was not found in ffts: fft was not inserted correctly"
+            got = got_ffts[fc]
 
             for field in mcd_model.KEYMAP.values():
                 # empty fields are by default set to '' (not None) even if they are numeric fields. Is this okay?
-                assert got.get(field, '') == expected.get(field, ''), f"{fg}: invalid field value '{field}'"
+                assert got.get(field, '') == expected.get(field, ''), f"{fc}: invalid field value '{field}'"
 
         assert len(got_ffts) == len(expected_ffts), "wrong number of fft fetched from db"
 
@@ -579,7 +579,7 @@ def test_export_csv_from_a_project(db):
     import_csv = """
 FC,Fungible,TC_part_no,Stand,State,Comments,LCLS_Z_loc,LCLS_X_loc,LCLS_Y_loc,LCLS_Z_roll,LCLS_X_pitch,LCLS_Y_yaw,Must_Ray_Trace
 AT1L0,COMBO,12324,SOME_TEST_STAND,Conceptual,TEST,1.21,0.21,2.213,1.231,,,
-AT1L0,GAS,3213221,,Conceptual,GAS ATTENUATOR,,,,1.23,-1.25,-0.895304,1
+AT2L0,GAS,3213221,,Conceptual,GAS ATTENUATOR,,,,1.23,-1.25,-0.895304,1
 """
 
     with io.StringIO() as stream:
@@ -596,7 +596,7 @@ AT1L0,GAS,3213221,,Conceptual,GAS ATTENUATOR,,,,1.23,-1.25,-0.895304,1
     expected_export = """
 FC,Fungible,TC_part_no,Stand,State,LCLS_Z_loc,LCLS_X_loc,LCLS_Y_loc,LCLS_Z_roll,LCLS_X_pitch,LCLS_Y_yaw,Must_Ray_Trace,Comments
 AT1L0,COMBO,12324,SOME_TEST_STAND,Conceptual,1.21,0.21,2.213,1.231,,,,TEST
-AT1L0,GAS,3213221,,Conceptual,,,,1.23,-1.25,-0.895304,1,GAS ATTENUATOR
+AT2L0,GAS,3213221,,Conceptual,,,,1.23,-1.25,-0.895304,1,GAS ATTENUATOR
 """
 
     csv = csv.replace("\r\n", "\n")


### PR DESCRIPTION
Sorry it's not broken down into commits/multiple pr's. Here's what's contained in the pr:

- Replaced FG values to be used as identifiers with the empty string FG db entry, making FC's the sole unique identifier 
  - For example, a uid in this scheme is " IM1K0-'' ". End user should only see it as "IM1K0". 
  - Users should have no way to interact with the FG column used in backend
- Added fg_desc ( description) as a column for end users to interact with purely as a descriptor column
- Removed FFT tab on main page, left the backend files because of possible need in the future
  - Removed the link from the title "Machine Configuration Database" to the projects page per suyun's request
- Bug fix for super approver emails and approver emails, altered when emails are sent and to which groups at project submission, and project updates after submission
- Updated the import template with correct headers
- Various tooltip text cleanups
- Few fixes for first time set up after an emptied db(creating new master project)