### PR TITLE
Added Github actions run

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,0 +1,34 @@
+name: Python Package using Conda
+
+on: [push]
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 5
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.12.7'
+    - name: Add conda to system path
+      run: |
+        # $CONDA is an environment variable pointing to the root of the miniconda directory
+        echo $CONDA/bin >> $GITHUB_PATH
+    - name: Install dependencies
+      run: |
+        conda env update --file environment.yml --name base
+    - name: Lint with flake8
+      run: |
+        conda install flake8
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        conda install pytest
+        pytest

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12.7
       uses: actions/setup-python@v3
       with:
         python-version: '3.12.7'
@@ -31,4 +31,4 @@ jobs:
     - name: Test with pytest
       run: |
         conda install pytest
-        pytest
+        python3 -m pytest tests

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -27,7 +27,9 @@ jobs:
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        #
+        # These are just stylistic issues, which aren't really important
+        # flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
         conda install pytest

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,6 +1,6 @@
 name: Run Licco Tests using Conda
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build-linux:
@@ -33,4 +33,4 @@ jobs:
     - name: Test with pytest
       run: |
         conda install pytest
-        conda run python -m pytest tests
+        pytest tests

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,4 +1,4 @@
-name: Python Package using Conda
+name: Run Licco Tests using Conda
 
 on: [push]
 

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -33,4 +33,5 @@ jobs:
     - name: Test with pytest
       run: |
         conda install pytest
-        pytest tests
+        conda run python -m pytest tests
+

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -31,4 +31,4 @@ jobs:
     - name: Test with pytest
       run: |
         conda install pytest
-        python3 -m pytest tests
+        conda run python -m pytest tests

--- a/environment.yml
+++ b/environment.yml
@@ -37,7 +37,7 @@ dependencies:
     - jinja2==3.1.2
     - markupsafe==2.1.3
     - packaging==23.2
-    - pymongo==4.5.0
+    - pymongo==4.9.1
     - mongomock==4.3.0
     - pytz==2023.3.post1
     - requests==2.31.0


### PR DESCRIPTION
Github actions execute everything within `tests/` folder in conda environment. I had to upgrade pymongo from 4.5.0 to 4.9.1 otherwise the build failed due to missing pymongo.synchronous package. We are using mongo mock for testing, but eventually we can upgrade to a full mongo instance.

The build currently fails due to the broken test case (which is not a part of this commit).


When merging please squash this mess. `.yml` files in online editors are impossible to deal with.