### PR TITLE
Fixed warnings reported by tests

### DIFF
--- a/dal/mcd_model.py
+++ b/dal/mcd_model.py
@@ -218,7 +218,7 @@ def get_all_projects(licco_db: MongoDb, logged_in_user, sort_criteria = None):
 
     if not sort_criteria:
         # order in descending order
-        sort_criteria = [["start_time", -1]]
+        sort_criteria = [["creation_time", -1]]
 
     all_projects = list(licco_db["projects"].find(filter).sort(sort_criteria))
     return all_projects
@@ -1362,18 +1362,6 @@ def reject_project(licco_db: MongoDb, prjid: str, userid: str, reason: str, noti
     return True, "", updated_project
 
 
-def get_currently_approved_project_by_switch(licco_db: MongoDb):
-    """
-    Get the current approved project.
-    This is really the most recently approved project
-    """
-    prjs = list(licco_db["switch"].find({}).sort([("switch_time", -1)]).limit(1))
-    if prjs:
-        current_id = prjs[0]["prj"]
-        return licco_db["projects"].find_one({"_id": current_id})
-    return None
-
-
 def get_master_project(licco_db: MongoDb):
     """
     Get the current approved project by status
@@ -1676,7 +1664,7 @@ def delete_project(licco_db: MongoDb, userid, project_id):
 
     allowed_to_delete = user_is_owner or user_is_admin
     if not allowed_to_delete:
-        return False, f"You don't have permission to delete the project {prj['name']}"
+        return False, f"You don't have permissions to delete the project {prj['name']}"
 
     if user_is_admin:
         # deletion for admin role means 'delete'

--- a/environment.yml
+++ b/environment.yml
@@ -37,7 +37,7 @@ dependencies:
     - jinja2==3.1.2
     - markupsafe==2.1.3
     - packaging==23.2
-    - pymongo==4.5.0
+    - pymongo==4.9.1
     - mongomock==4.3.0
     - pytz==2023.3.post1
     - requests==2.31.0

--- a/tests/test_mcd_model.py
+++ b/tests/test_mcd_model.py
@@ -259,7 +259,6 @@ def test_copy_fft_values(db):
     # after copy there should be fft with the chosen fields within the 'b' project
     b_ffts = mcd_model.get_project_ffts(db, b["_id"])
     assert len(b_ffts) == 1, "there should be 1 fft present in 'b' after copy"
-    print(b_ffts)
     fft = list(b_ffts.values())[0]
     assert fft['comments'] == 'project_a comment'
     assert fft['nom_ang_x'] == 2.45


### PR DESCRIPTION
Replaced deprecated method. The code will now run only with python 3.11 or later (we never discussed which is the earliest version that we are supposed to support)