### PR TITLE
Pymongo topology logs filter/Human Readable Columns

### DIFF
--- a/react/src/app/ffts/ffts_overview.tsx
+++ b/react/src/app/ffts/ffts_overview.tsx
@@ -52,7 +52,7 @@ export const FFTOverviewTable: React.FC = () => {
                     <tr>
                         <th scope="col" className="text-nowrap">
                             <ButtonGroup>
-                                <Button icon="add" title="Add a new FFT" small={true} minimal={true}
+                                <Button icon="add" title="Add a new FC" small={true} minimal={true}
                                     onClick={e => setIsFftDialogOpen(true)}
                                 />
                                 {isLoading ? <Button loading={isLoading} minimal={true} /> : null}
@@ -217,7 +217,7 @@ export const AddFftDialog: React.FC<{ isOpen: boolean, ffts?: FFTInfo[], dialogT
     }
 
     return (
-        <Dialog isOpen={isOpen} onClose={onClose} title="Add a new FFT" autoFocus={true} style={{ width: "70ch" }}>
+        <Dialog isOpen={isOpen} onClose={onClose} title="Add a New FC" autoFocus={true} style={{ width: "70ch" }}>
             <DialogBody useOverflowScrollContainer>
                 <p>Please choose/enter a functional component name.
                     You can choose one of the existing entities or you can type in a brand new functional component name.

--- a/react/src/app/projects/[projectId]/project_details.tsx
+++ b/react/src/app/projects/[projectId]/project_details.tsx
@@ -84,8 +84,7 @@ export const ProjectDetails: React.FC<{ projectId: string }> = ({ projectId }) =
     const [fftData, setFftData] = useState<ProjectDeviceDetails[]>([]);
     const [fftDataDisplay, setFftDataDisplay] = useState<ProjectDeviceDetails[]>([]);
     const [currentlyLoggedInUser, setCurrentlyLoggedInUser] = useState<string>('');
-    const [keymap, setKeymap] = useState(String);
-
+    const [keymap, setKeymap] = useState<Record<string, string>>({});
 
     // dialogs open state
     const [isAddNewFftDialogOpen, setIsAddNewFftDialogOpen] = useState(false);
@@ -776,7 +775,7 @@ const DeviceDataTableRow: React.FC<{ project?: ProjectInfo, device: ProjectDevic
 
 const DeviceDataEditTableRow: React.FC<{
     project?: ProjectInfo,
-    keymap: object,
+    keymap: Record<string, string>,
     device: ProjectDeviceDetails,
     availableFftStates: DeviceState[],
     onEditDone: (newDevice: ProjectDeviceDetails, action: "ok" | "cancel") => void,

--- a/react/src/app/projects/[projectId]/project_details.tsx
+++ b/react/src/app/projects/[projectId]/project_details.tsx
@@ -595,8 +595,8 @@ export const ProjectDetails: React.FC<{ projectId: string }> = ({ projectId }) =
                             });
                     }}
                 >
-                    <h5 className="alert-title"><Icon icon="trash" />Delete {currentFFT.fc}-{currentFFT.fg}?</h5>
-                    <p>Do you really want to delete a device <b>{currentFFT.fc}-{currentFFT.fg}</b> from a project <b>{project.name}</b>?</p>
+                    <h5 className="alert-title"><Icon icon="trash" />Delete {currentFFT.fc}?</h5>
+                    <p>Do you really want to delete a device <b>{currentFFT.fc}</b> from a project <b>{project.name}</b>?</p>
                     <p><i>This will permanently delete the entire history of device value changes, as well as all related discussion comments!</i></p>
                 </Alert>
                 : null

--- a/react/src/app/projects/[projectId]/project_details.tsx
+++ b/react/src/app/projects/[projectId]/project_details.tsx
@@ -84,7 +84,7 @@ export const ProjectDetails: React.FC<{ projectId: string }> = ({ projectId }) =
     const [fftData, setFftData] = useState<ProjectDeviceDetails[]>([]);
     const [fftDataDisplay, setFftDataDisplay] = useState<ProjectDeviceDetails[]>([]);
     const [currentlyLoggedInUser, setCurrentlyLoggedInUser] = useState<string>('');
-    const [keymap, setKeymap] = useState(Object);
+    const [keymap, setKeymap] = useState(String);
 
 
     // dialogs open state

--- a/react/src/app/projects/[projectId]/project_dialogs.tsx
+++ b/react/src/app/projects/[projectId]/project_dialogs.tsx
@@ -356,7 +356,7 @@ export const CopyFFTToProjectDialog: React.FC<{ isOpen: boolean, currentProject:
   )
 };
 
-export const ProjectHistoryDialog: React.FC<{ isOpen: boolean, currentProject: ProjectInfo, onClose: () => void, displayProjectSince: (time: Date) => void }> = ({ isOpen, currentProject, onClose, displayProjectSince }) => {
+export const ProjectHistoryDialog: React.FC<{ isOpen: boolean, keymap: object, currentProject: ProjectInfo, onClose: () => void, displayProjectSince: (time: Date) => void }> = ({ isOpen, keymap, currentProject, onClose, displayProjectSince }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [dialogErr, setDialogErr] = useState('');
   const [data, setData] = useState<ProjectHistoryChange[]>([])
@@ -401,7 +401,7 @@ export const ProjectHistoryDialog: React.FC<{ isOpen: boolean, currentProject: P
         <thead>
           <tr>
             <th></th>
-            <th>FFT</th>
+            <th>FC</th>
             <th>Attribute</th>
             <th>Value</th>
             <th className="text-nowrap">Changed By</th>
@@ -421,8 +421,8 @@ export const ProjectHistoryDialog: React.FC<{ isOpen: boolean, currentProject: P
                     onClick={(e) => displayProjectSince(change.time)}
                   /> : null}
                 </td>
-                <td>{change.fc}-{change.fg}</td>
-                <td>{change.key}</td>
+                <td>{change.fc}</td>
+                <td>{keymap[change.key]}</td>
                 <td>{change.val}</td>
                 <td>{change.user}</td>
                 <td>{formatToLiccoDateTime(change.time)}</td>
@@ -649,7 +649,7 @@ const sortProjectValueChanges = (changes: Record<string, any>) => {
 }
 
 // dialog for confirming the changed values and adding comments to value change
-export const ProjectEditConfirmDialog: React.FC<{ isOpen: boolean, project: ProjectInfo, device: ProjectDeviceDetails, valueChanges: Record<string, any>, onClose: () => void, onSubmit: (device: ProjectDeviceDetails) => void }> = ({ isOpen, project, device, valueChanges, onClose, onSubmit }) => {
+export const ProjectEditConfirmDialog: React.FC<{ isOpen: boolean, keymap: object, project: ProjectInfo, device: ProjectDeviceDetails, valueChanges: Record<string, any>, onClose: () => void, onSubmit: (device: ProjectDeviceDetails) => void }> = ({ isOpen, keymap, project, device, valueChanges, onClose, onSubmit }) => {
   const [dialogErr, setDialogErr] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [comment, setComment] = useState('');
@@ -668,7 +668,7 @@ export const ProjectEditConfirmDialog: React.FC<{ isOpen: boolean, project: Proj
     const d = device as any;
     return (
       <>
-        <b>{device.fc}-{device.fg} Changes:</b>
+        <b>{device.fc} Changes:</b>
         <table className="table table-sm table-bordered table-striped">
           <thead>
             <tr>
@@ -682,7 +682,7 @@ export const ProjectEditConfirmDialog: React.FC<{ isOpen: boolean, project: Proj
             {values.map((entry) => {
               return (
                 <tr key={entry[0]}>
-                  <td>{entry[0]}</td>
+                  <td>{keymap[entry[0]]}</td>
                   <td>{d[entry[0]]}</td>
                   <td className="text-center"><Icon icon="arrow-right" color={Colors.GRAY1}></Icon></td>
                   <td>{entry[1]}</td>
@@ -737,7 +737,7 @@ export const ProjectEditConfirmDialog: React.FC<{ isOpen: boolean, project: Proj
   }, [device.discussion]);
 
   return (
-    <Dialog isOpen={isOpen} onClose={onClose} title={`Save Changes for ${device.fc}-${device.fg}?`} autoFocus={true} style={{ width: "75ch", maxWidth: "95%" }}>
+    <Dialog isOpen={isOpen} onClose={onClose} title={`Save Changes for ${device.fc}?`} autoFocus={true} style={{ width: "75ch", maxWidth: "95%" }}>
       <DialogBody useOverflowScrollContainer>
         {projectChangeTable}
 

--- a/react/src/app/projects/[projectId]/project_dialogs.tsx
+++ b/react/src/app/projects/[projectId]/project_dialogs.tsx
@@ -356,7 +356,7 @@ export const CopyFFTToProjectDialog: React.FC<{ isOpen: boolean, currentProject:
   )
 };
 
-export const ProjectHistoryDialog: React.FC<{ isOpen: boolean, keymap: object, currentProject: ProjectInfo, onClose: () => void, displayProjectSince: (time: Date) => void }> = ({ isOpen, keymap, currentProject, onClose, displayProjectSince }) => {
+export const ProjectHistoryDialog: React.FC<{ isOpen: boolean, keymap: string, currentProject: ProjectInfo, onClose: () => void, displayProjectSince: (time: Date) => void }> = ({ isOpen, keymap, currentProject, onClose, displayProjectSince }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [dialogErr, setDialogErr] = useState('');
   const [data, setData] = useState<ProjectHistoryChange[]>([])
@@ -649,7 +649,7 @@ const sortProjectValueChanges = (changes: Record<string, any>) => {
 }
 
 // dialog for confirming the changed values and adding comments to value change
-export const ProjectEditConfirmDialog: React.FC<{ isOpen: boolean, keymap: object, project: ProjectInfo, device: ProjectDeviceDetails, valueChanges: Record<string, any>, onClose: () => void, onSubmit: (device: ProjectDeviceDetails) => void }> = ({ isOpen, keymap, project, device, valueChanges, onClose, onSubmit }) => {
+export const ProjectEditConfirmDialog: React.FC<{ isOpen: boolean, keymap: string, project: ProjectInfo, device: ProjectDeviceDetails, valueChanges: Record<string, any>, onClose: () => void, onSubmit: (device: ProjectDeviceDetails) => void }> = ({ isOpen, keymap, project, device, valueChanges, onClose, onSubmit }) => {
   const [dialogErr, setDialogErr] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [comment, setComment] = useState('');

--- a/react/src/app/projects/[projectId]/project_dialogs.tsx
+++ b/react/src/app/projects/[projectId]/project_dialogs.tsx
@@ -356,7 +356,7 @@ export const CopyFFTToProjectDialog: React.FC<{ isOpen: boolean, currentProject:
   )
 };
 
-export const ProjectHistoryDialog: React.FC<{ isOpen: boolean, keymap: string, currentProject: ProjectInfo, onClose: () => void, displayProjectSince: (time: Date) => void }> = ({ isOpen, keymap, currentProject, onClose, displayProjectSince }) => {
+export const ProjectHistoryDialog: React.FC<{ isOpen: boolean, keymap: Record<string, string>, currentProject: ProjectInfo, onClose: () => void, displayProjectSince: (time: Date) => void }> = ({ isOpen, keymap, currentProject, onClose, displayProjectSince }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [dialogErr, setDialogErr] = useState('');
   const [data, setData] = useState<ProjectHistoryChange[]>([])
@@ -649,7 +649,7 @@ const sortProjectValueChanges = (changes: Record<string, any>) => {
 }
 
 // dialog for confirming the changed values and adding comments to value change
-export const ProjectEditConfirmDialog: React.FC<{ isOpen: boolean, keymap: string, project: ProjectInfo, device: ProjectDeviceDetails, valueChanges: Record<string, any>, onClose: () => void, onSubmit: (device: ProjectDeviceDetails) => void }> = ({ isOpen, keymap, project, device, valueChanges, onClose, onSubmit }) => {
+export const ProjectEditConfirmDialog: React.FC<{ isOpen: boolean, keymap: Record<string, string>, project: ProjectInfo, device: ProjectDeviceDetails, valueChanges: Record<string, any>, onClose: () => void, onSubmit: (device: ProjectDeviceDetails) => void }> = ({ isOpen, keymap, project, device, valueChanges, onClose, onSubmit }) => {
   const [dialogErr, setDialogErr] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [comment, setComment] = useState('');

--- a/react/src/app/projects/project_model.tsx
+++ b/react/src/app/projects/project_model.tsx
@@ -74,6 +74,14 @@ export async function fetchProjectInfo(projectId: string): Promise<ProjectInfo> 
         });
 }
 
+export async function fetchKeymap(): Promise<object> {
+    return Fetch.get<object>(`/ws/backendkeymap/`)
+        .then((response) => {
+            return response;
+        });
+}
+
+
 interface UsersByRole {
     all?: string[];
     editors?: string[];

--- a/react/src/app/projects/project_model.tsx
+++ b/react/src/app/projects/project_model.tsx
@@ -74,8 +74,8 @@ export async function fetchProjectInfo(projectId: string): Promise<ProjectInfo> 
         });
 }
 
-export async function fetchKeymap(): Promise<string> {
-    return Fetch.get<string>(`/ws/backendkeymap/`)
+export async function fetchKeymap(): Promise<Record<string, string>> {
+    return Fetch.get<Record<string, string>>(`/ws/backendkeymap/`)
         .then((response) => {
             return response;
         });

--- a/react/src/app/projects/project_model.tsx
+++ b/react/src/app/projects/project_model.tsx
@@ -74,8 +74,8 @@ export async function fetchProjectInfo(projectId: string): Promise<ProjectInfo> 
         });
 }
 
-export async function fetchKeymap(): Promise<object> {
-    return Fetch.get<object>(`/ws/backendkeymap/`)
+export async function fetchKeymap(): Promise<string> {
+    return Fetch.get<string>(`/ws/backendkeymap/`)
         .then((response) => {
             return response;
         });

--- a/services/licco.py
+++ b/services/licco.py
@@ -71,10 +71,13 @@ def svc_get_fcattrs():
 def svc_get_keymap():
     """
     Returns the keymap responsible for mapping backend names to human readable ones
-    (For frontend/react needs)
+    (For frontend/react needs, adds in additional frontend attributes)
     Ex: nom_loc_x -> LCLS_X_loc or fg_desc -> Fungible
     """
-    return json_response(mcd_model.KEYMAP_REVERSE)
+    return json_response(dict(
+        discussion="Discussion",
+        **mcd_model.KEYMAP_REVERSE,
+    ))
 
 @licco_ws_blueprint.route("/users/", methods=["GET"])
 @context.security.authentication_required

--- a/services/licco.py
+++ b/services/licco.py
@@ -66,6 +66,15 @@ def svc_get_fcattrs():
     """
     return json_response(mcd_model.get_fcattrs())
 
+@licco_ws_blueprint.route("/backendkeymap/", methods=["GET"])
+@context.security.authentication_required
+def svc_get_keymap():
+    """
+    Returns the keymap responsible for mapping backend names to human readable ones
+    (For frontend/react needs)
+    Ex: nom_loc_x -> LCLS_X_loc or fg_desc -> Fungible
+    """
+    return json_response(mcd_model.KEYMAP_REVERSE)
 
 @licco_ws_blueprint.route("/users/", methods=["GET"])
 @context.security.authentication_required

--- a/start.py
+++ b/start.py
@@ -65,6 +65,8 @@ else:
 
 root = logging.getLogger()
 root.setLevel(logging.getLevelName(os.environ.get("LOG_LEVEL", "INFO")))
+# filter out server heartbeat logs
+logging.getLogger('pymongo.topology').setLevel(level=logging.WARNING)
 ch = logging.StreamHandler(sys.stdout)
 ch.setLevel(logging.DEBUG)
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')


### PR DESCRIPTION
- Set pymongo.topology (Server heartbeat) logs to warning to stop clogging dev server
- Add a fetch keymap function to convert db column names to the slightly more human readable ones we define in the backend
- Use that function in History and Edit FFT comments
- Also cleanup some leftover FFT fields to FC