### PR TITLE
Use real MongoDb on Github Actions

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -7,7 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 5
-
+    services:
+      mongo:
+        image: "mongo"
+        ports: 
+          - 27017:27017
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.12.7

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 5
     services:
       mongo:
-        image: "mongo"
+        image: "mongo:8.0.0"
         ports: 
           - 27017:27017
     steps:


### PR DESCRIPTION
There's a bug in mongomock, which sometimes throws an exception and fails the test suite, despite our tests working correctly on a real mongo instance. I changed the Github actions to use a real mongo service instead. This will also let us start migrating our backend to use transactions as mongomock does not support them.